### PR TITLE
serve static files

### DIFF
--- a/main.go
+++ b/main.go
@@ -259,10 +259,6 @@ func main() {
 		dcrwClient.Disconnect()
 		os.Exit(1)
 	}()
-	http.Handle("/js/", http.StripPrefix("/js/", http.FileServer(http.Dir("public/js/"))))
-	http.Handle("/css/", http.StripPrefix("/css/", http.FileServer(http.Dir("public/css/"))))
-	http.Handle("/fonts/", http.StripPrefix("/fonts/", http.FileServer(http.Dir("public/fonts/"))))
-	http.Handle("/images/", http.StripPrefix("/images/", http.FileServer(http.Dir("public/images/"))))
 
 	// CORS options
 	origins := handlers.AllowedOrigins([]string{"*"})
@@ -270,6 +266,12 @@ func main() {
 	headers := handlers.AllowedHeaders([]string{"Content-Type"})
 
 	r := mux.NewRouter()
+
+	r.PathPrefix("/js/").Handler(http.StripPrefix("/js/", http.FileServer(http.Dir("public/js"))))
+	r.PathPrefix("/css/").Handler(http.StripPrefix("/css/", http.FileServer(http.Dir("public/css"))))
+	r.PathPrefix("/fonts/").Handler(http.StripPrefix("/fonts/", http.FileServer(http.Dir("public/fonts"))))
+	r.PathPrefix("/images/").Handler(http.StripPrefix("/images/", http.FileServer(http.Dir("public/images"))))
+
 	r.HandleFunc("/", requestFunds)
 
 	err = http.ListenAndServe(cfg.Listen,

--- a/public/views/design_sketch.html
+++ b/public/views/design_sketch.html
@@ -73,7 +73,7 @@
           </div>
           {{end}}
 	        <!-- FORM BEGINS HERE -->
-          <form action="/requestfaucet" class="form-horizontal" method="post">
+          <form class="form-horizontal" method="post">
 	          <div class="form-group">
               <input class="form-control input-md" type="text" name="address" placeholder="Address" required>
               <input type="hidden" name="amount">

--- a/sample-testnetfaucet.conf
+++ b/sample-testnetfaucet.conf
@@ -1,13 +1,19 @@
 ; overridetoken bypasses the rate limiter.  Required.
 ;overridetoken=developers!developers!developers!
 
-; wallet rpc connection stuff.  Required.
+; Wallet rpc connection stuff.  Required.
 ;wallethost=127.0.0.1
 ;walletuser=user
 ;walletpassword=pass
 
-; These values are set by default to the sane values below.
-;walletaddress=TsfDLrRkk9ciUuwfp2b8PawwnukYD7yAjGd
+; wallet rpc cert. Optional.
 ;walletcert=~/.dcrwallet/rpc.cert
+
+; Address displayed on the webpage for returning coins. Optional.
+;walletaddress=TsfDLrRkk9ciUuwfp2b8PawwnukYD7yAjGd
+
+; Maximum amount of dcr to send in each request. Optional.
 ;withdrawalamount=2
+
+; Number of seconds users need to wait before making another request. Optional.
 ;withdrawaltimelimit=30


### PR DESCRIPTION
Fixes an issue where the static html resources are not being served by the http server

Also remove route `/requestfaucet`  from the form, because actually the server is expecting the POST request to come into `/`

edit: PR also includes some updates to the config file comments. I commited this by mistake, but it might as well go in