### PR TITLE
routing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 testnetfaucet
 *~
 vendor/
+.vscode/launch.json
+debug

--- a/public/views/design_sketch.html
+++ b/public/views/design_sketch.html
@@ -34,7 +34,7 @@
     <nav class="navbar navbar-default navbar-fixed-top">
       <div class="container">
         <div class="navbar-header">
-          <a class="navbar-brand" href="#">
+          <a class="navbar-brand" href="/">
             <svg class="svg-logo">
               <use xlink:href="/images/sprites.svg#svg-decred-logo" />
             </svg>
@@ -69,11 +69,11 @@
           {{end}}
           {{if .Success}}
           <div class="alert alert-success">
-            <p>Success! Transaction {{.Success}} has been sent.  You may see it on <a href="https://testnet.dcrdata.org/explorer/tx/{{.Success}}">dcrdata</a> or <a href="https://testnet.decred.org/tx/{{.Success}}">Insight</a>.</p>
+            <p>Success! Transaction {{.Success}} has been sent.  You may see it on <a href="https://testnet.dcrdata.org/explorer/tx/{{.Success}}">dcrdata</a>.</p>
           </div>
           {{end}}
 	        <!-- FORM BEGINS HERE -->
-          <form action="/requestfaucet" class="form-horizontal" method="post">
+          <form class="form-horizontal" method="post">
 	          <div class="form-group">
               <input class="form-control input-md" type="text" name="address" placeholder="Address" required>
               <input type="hidden" name="amount">

--- a/sample-testnetfaucet.conf
+++ b/sample-testnetfaucet.conf
@@ -1,13 +1,19 @@
 ; overridetoken bypasses the rate limiter.  Required.
 ;overridetoken=developers!developers!developers!
 
-; wallet rpc connection stuff.  Required.
+; Wallet rpc connection stuff.  Required.
 ;wallethost=127.0.0.1
 ;walletuser=user
 ;walletpassword=pass
 
-; These values are set by default to the sane values below.
-;walletaddress=TsfDLrRkk9ciUuwfp2b8PawwnukYD7yAjGd
+; Wallet rpc cert. Optional.
 ;walletcert=~/.dcrwallet/rpc.cert
+
+; Address displayed on the webpage for returning coins. Optional.
+;walletaddress=TsfDLrRkk9ciUuwfp2b8PawwnukYD7yAjGd
+
+; Maximum amount of dcr to send in each request. Optional.
 ;withdrawalamount=2
+
+; Number of seconds users need to wait before making another request. Optional.
 ;withdrawaltimelimit=30


### PR DESCRIPTION
- Static files are not currently served by the http server (since #41). This PR fixes it.
- Remove link to insight block explorer (keeping the dcrdata link)
- Remove the form action `/requestfaucet` and POST to `/` instead. This prevents the users browser from opening the `/requestfaucet` URL.
