### PR TITLE
Add SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Decred project runs a bug bounty program which is approved by the stakeholders and is funded by the Decred treasury.
+
+Please refer to the bounty website to understand the [scope](https://bounty.decred.org/#Scope) and how to [submit](https://bounty.decred.org/#Submit%20Vulnerability) a vulnerability.
+
+https://bounty.decred.org/
+
+## Supported Versions
+
+All bugs must be reproducible in the latest production release or the master branch of the code.
+


### PR DESCRIPTION
Adds a SECURITY.md file which is shown in the [security](../security/policy) tab on github. 